### PR TITLE
Fix GGC

### DIFF
--- a/gcc/ipa-fnsummary.cc
+++ b/gcc/ipa-fnsummary.cc
@@ -4986,4 +4986,6 @@ void
 ipa_fnsummary_cc_finalize (void)
 {
   ipa_free_fn_summary ();
+  // TODO: this commit contains many fixes that don't necessarily help fixing the bug in the GC. Remove those fixes.
+  ipa_free_size_summary ();
 }

--- a/gcc/ipa-icf.cc
+++ b/gcc/ipa-icf.cc
@@ -3656,3 +3656,12 @@ make_pass_ipa_icf (gcc::context *ctxt)
 {
   return new ipa_icf::pass_ipa_icf (ctxt);
 }
+
+/* Reset all state within ipa-icf.cc so that we can rerun the compiler
+   within the same process.  For use by toplev::finalize.  */
+
+void
+ipa_icf_cc_finalize (void)
+{
+  ipa_icf::optimizer = NULL;
+}

--- a/gcc/ipa-profile.cc
+++ b/gcc/ipa-profile.cc
@@ -1065,3 +1065,13 @@ make_pass_ipa_profile (gcc::context *ctxt)
 {
   return new pass_ipa_profile (ctxt);
 }
+
+/* Reset all state within ipa-profile.cc so that we can rerun the compiler
+   within the same process.  For use by toplev::finalize.  */
+
+void
+ipa_profile_cc_finalize (void)
+{
+  delete call_sums;
+  call_sums = NULL;
+}

--- a/gcc/ipa-prop.cc
+++ b/gcc/ipa-prop.cc
@@ -6001,5 +6001,23 @@ ipcp_transform_function (struct cgraph_node *node)
   return modified_mem_access ? TODO_update_ssa_only_virtuals : 0;
 }
 
+/* Reset all state within ipa-prop.cc so that we can rerun the compiler
+   within the same process.  For use by toplev::finalize.  */
+
+void
+ipa_prop_cc_finalize (void)
+{
+  if (function_insertion_hook_holder)
+    symtab->remove_cgraph_insertion_hook (function_insertion_hook_holder);
+  function_insertion_hook_holder = NULL;
+
+  if (ipa_edge_args_sum)
+    ggc_delete (ipa_edge_args_sum);
+  ipa_edge_args_sum = NULL;
+
+  if (ipa_node_params_sum)
+    ggc_delete (ipa_node_params_sum);
+  ipa_node_params_sum = NULL;
+}
 
 #include "gt-ipa-prop.h"

--- a/gcc/ipa-prop.h
+++ b/gcc/ipa-prop.h
@@ -1162,6 +1162,8 @@ bool ipcp_get_parm_bits (tree, tree *, widest_int *);
 bool unadjusted_ptr_and_unit_offset (tree op, tree *ret,
 				     poly_int64 *offset_ret);
 
+void ipa_prop_cc_finalize (void);
+
 /* From tree-sra.cc:  */
 tree build_ref_for_offset (location_t, tree, poly_int64, bool, tree,
 			   gimple_stmt_iterator *, bool);

--- a/gcc/ipa-sra.cc
+++ b/gcc/ipa-sra.cc
@@ -4540,5 +4540,17 @@ make_pass_ipa_sra (gcc::context *ctxt)
   return new pass_ipa_sra (ctxt);
 }
 
+/* Reset all state within ipa-sra.cc so that we can rerun the compiler
+   within the same process.  For use by toplev::finalize.  */
+
+void
+ipa_sra_cc_finalize (void)
+{
+  if (func_sums)
+    ggc_delete (func_sums);
+  func_sums = NULL;
+  delete call_sums;
+  call_sums = NULL;
+}
 
 #include "gt-ipa-sra.h"

--- a/gcc/ipa-utils.h
+++ b/gcc/ipa-utils.h
@@ -55,6 +55,13 @@ bool ipa_make_function_pure (cgraph_node *, bool, bool);
 
 /* In ipa-profile.cc  */
 bool ipa_propagate_frequency (struct cgraph_node *node);
+void ipa_profile_cc_finalize (void);
+
+/* In ipa-icf.cc  */
+void ipa_icf_cc_finalize (void);
+
+/* In ipa-sra.cc  */
+void ipa_sra_cc_finalize (void);
 
 /* In ipa-devirt.cc  */
 

--- a/gcc/toplev.cc
+++ b/gcc/toplev.cc
@@ -75,6 +75,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "symbol-summary.h"
 #include "tree-vrp.h"
 #include "ipa-prop.h"
+#include "ipa-utils.h"
 #include "gcse.h"
 #include "omp-offload.h"
 #include "edit-context.h"
@@ -1079,11 +1080,14 @@ general_init (const char *argv0, bool init_signals)
   init_ggc ();
   init_stringpool ();
   input_location = UNKNOWN_LOCATION;
-  line_table = ggc_alloc<line_maps> ();
-  linemap_init (line_table, BUILTINS_LOCATION);
-  line_table->reallocator = realloc_for_line_map;
-  line_table->round_alloc_size = ggc_round_alloc_size;
-  line_table->default_range_bits = 5;
+  if (!line_table)
+  {
+    line_table = ggc_alloc<line_maps> ();
+    linemap_init (line_table, BUILTINS_LOCATION);
+    line_table->reallocator = realloc_for_line_map;
+    line_table->round_alloc_size = ggc_round_alloc_size;
+    line_table->default_range_bits = 5;
+  }
   init_ttree ();
 
   /* Initialize register usage now so switches may override.  */
@@ -2327,7 +2331,11 @@ toplev::finalize (void)
   ipa_fnsummary_cc_finalize ();
   ipa_modref_cc_finalize ();
   ipa_edge_modifications_finalize ();
+  ipa_icf_cc_finalize ();
 
+  ipa_prop_cc_finalize ();
+  ipa_profile_cc_finalize ();
+  ipa_sra_cc_finalize ();
   cgraph_cc_finalize ();
   cgraphunit_cc_finalize ();
   symtab_thunks_cc_finalize ();


### PR DESCRIPTION
This fix a bug in the garbage collector of GCC that happens when compiling multiple times with `-flto` enabled.