### PR TITLE
Change the type of targetjitm to gcc_targetjitm

### DIFF
--- a/gcc/config/default-jit.cc
+++ b/gcc/config/default-jit.cc
@@ -25,4 +25,4 @@ along with GCC; see the file COPYING3.  If not see
 /* Do not include tm.h or tm_p.h here; definitions needed by the target
    architecture to initialize targetjitm should instead be added to tm_jit.h.  */
 
-struct gcc_targetdm targetjitm = TARGETJITM_INITIALIZER;
+struct gcc_targetjitm targetjitm = TARGETJITM_INITIALIZER;


### PR DESCRIPTION
Currently, targetjitm in gcc/config/default-jit.cc has its type set to gcc_targetdm, when it should be gcc_targetjitm, which that cross compilers won't compile. This fixes that.