### PR TITLE
feat(gccjit): Allow set_loccation to various classes

### DIFF
--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -1044,6 +1044,7 @@ class array_type : public type
   bool is_signed () const final override { return false; }
 
   void replay_into (replayer *) final override;
+  void set_loc(location * loc) { m_loc = loc; }
 
  private:
   string * make_debug_string () final override;
@@ -1133,6 +1134,7 @@ public:
 
   compound_type * get_container () const { return m_container; }
   void set_container (compound_type *c) { m_container = c; }
+  void set_loc (location * loc) { m_loc = loc; }
 
   void replay_into (replayer *) override;
 
@@ -1207,6 +1209,7 @@ public:
   bool is_signed () const final override { return false; }
 
   bool has_known_size () const final override { return m_fields != NULL; }
+  void set_loc (location * loc) { m_loc = loc; }
 
   playback::compound_type *
   playback_compound_type ()
@@ -1348,6 +1351,7 @@ public:
   }
 
   location * get_loc () const { return m_loc; }
+  void set_loc (location * loc) { m_loc = loc; }
 
   /* Get the recording::type of this rvalue.
 
@@ -1539,6 +1543,7 @@ public:
   new_block (const char *name);
 
   location *get_loc () const { return m_loc; }
+  void set_loc (location * loc) { m_loc = loc; }
   type *get_return_type () const { return m_return_type; }
   string * get_name () const { return m_name; }
   const vec<param *> &get_params () const { return m_params; }
@@ -1676,6 +1681,7 @@ public:
   bool validate ();
 
   location *get_loc () const;
+  void set_loc (location * loc);
 
   statement *get_first_statement () const;
   statement *get_last_statement () const;
@@ -2483,6 +2489,7 @@ public:
 
   block *get_block () const { return m_block; }
   location *get_loc () const { return m_loc; }
+  void set_loc (location * loc) { m_loc = loc; }
 
 protected:
   statement (block *b, location *loc)

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -4749,3 +4749,46 @@ gcc_jit_context_add_top_level_asm (gcc_jit_context *ctxt,
   RETURN_IF_FAIL (asm_stmts, ctxt, NULL, "NULL asm_stmts");
   ctxt->add_top_level_asm (loc, asm_stmts);
 }
+
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, this calls the trivial
+   gcc::jit::recording::field::set_loc method, in jit-recording.h.  */
+
+void
+gcc_jit_field_set_location (gcc_jit_field *field,
+                            gcc_jit_location *loc)
+{
+  RETURN_IF_FAIL (field, NULL, NULL, "NULL field");
+
+  field->set_loc (loc);
+}
+
+
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, this calls the trivial
+   gcc::jit::recording::rvalue::set_loc method , in jit-recording.h.  */
+
+void
+gcc_jit_rvalue_set_location (gcc_jit_rvalue *rvalue,
+			     gcc_jit_location *loc)
+{
+  RETURN_IF_FAIL (rvalue, NULL, NULL, "NULL rvalue");
+
+  rvalue->set_loc (loc);
+}
+
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, this calls the trivial
+   gcc::jit::recording::function::set_loc method, in jit-recording.h.  */
+
+void
+gcc_jit_function_set_location (gcc_jit_function *func,
+                               gcc_jit_location *loc)
+{
+  RETURN_IF_FAIL (func, NULL, NULL, "NULL func");
+
+  func->set_loc (loc);
+}

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -2183,6 +2183,16 @@ gcc_jit_target_info_supports_128bit_int (gcc_jit_target_info *info);
 extern void
 gcc_jit_type_set_packed (gcc_jit_type *type);
 
+extern void
+gcc_jit_field_set_location (gcc_jit_field *field,
+			    gcc_jit_location *loc);
+extern void
+gcc_jit_function_set_location (gcc_jit_function *func,
+			       gcc_jit_location *loc);
+extern void
+gcc_jit_rvalue_set_location (gcc_jit_rvalue *rvalue,
+			     gcc_jit_location *loc);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -340,3 +340,10 @@ LIBGCCJIT_ABI_36 {
   global:
     gcc_jit_function_new_temp;
 } LIBGCCJIT_ABI_35;
+
+LIBGCCJIT_ABI_37 {
+   global:
+    gcc_jit_field_set_location;
+    gcc_jit_function_set_location;
+    gcc_jit_rvalue_set_location;
+} LIBGCCJIT_ABI_36;


### PR DESCRIPTION
Including:
1. field
2. function
3. rvalue


This is part of my initial draft of debuginfo. It is part of the prerequisites to merge my debuginfo support. 
Note: Only C interface is supported and only RValue is currently in use. Of course, if you insist, I can also create a commit with other extra parts removed. 